### PR TITLE
Add YouTube channel URL support for bulk downloads

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -413,7 +413,7 @@
       <h1 class="brand">VIDIGO</h1>
       <div class="sub">
         Instagram hesap URL'si girilirse hesapta gorunen reels/videolar toplu indirilir ve batch akista her oge m4a olarak saklanir. Instagram reel URL'si girilirse tekli akista video tutulmaz, m4a dosyasi kalir ve Whisper metni ciktiya yazilir.
-        YouTube playlist URL'si girilirse tum playlist batch akista m4a olarak iner. Tek video URL'si girilirse video yerine m4a saklanir ve Whisper transkripti ciktiya eklenir.
+        YouTube playlist veya kanal URL'si girilirse tum videolar batch akista m4a olarak iner. Tek video URL'si girilirse video yerine m4a saklanir ve Whisper transkripti ciktiya eklenir.
         Her islem platform ve kaynak adina gore ayri manifest JSON'a kaydedilir.
       </div>
     </div>
@@ -432,10 +432,11 @@
       <section class="panel" id="singlePanel">
         <div class="eyebrow"><span>01</span> Tek URL Indir</div>
         <label class="label" for="videoUrl">YouTube veya Instagram URL</label>
-        <input type="text" id="videoUrl" placeholder="ornek: https://www.instagram.com/ornekhesap/ veya https://www.youtube.com/playlist?list=..." />
+        <input type="text" id="videoUrl" placeholder="ornek: https://www.youtube.com/@kanaladi/videos veya https://www.youtube.com/playlist?list=..." />
         <div class="badge-row">
           <div class="badge">YouTube video</div>
           <div class="badge">YouTube playlist</div>
+          <div class="badge">YouTube channel</div>
           <div class="badge">Instagram reel</div>
           <div class="badge">Instagram hesap</div>
         </div>

--- a/utils/download_service.py
+++ b/utils/download_service.py
@@ -16,6 +16,7 @@ from utils.video_downloader import (
 )
 from utils.youtube_utils import (
     extract_youtube_video_id,
+    is_youtube_channel_url,
     is_youtube_playlist_url,
     is_youtube_url,
 )
@@ -34,9 +35,11 @@ def classify_download_url(url):
     if is_youtube_url(normalized):
         if is_youtube_playlist_url(normalized):
             return {"platform": "youtube", "source_type": "playlist", "url": normalized}
+        if is_youtube_channel_url(normalized):
+            return {"platform": "youtube", "source_type": "channel", "url": normalized}
         if extract_youtube_video_id(normalized):
             return {"platform": "youtube", "source_type": "video", "url": normalized}
-        raise ValueError("Gecerli bir YouTube video veya playlist URL'si girin.")
+        raise ValueError("Gecerli bir YouTube video, playlist veya kanal URL'si girin.")
 
     if is_instagram_url(normalized):
         if extract_instagram_shortcode(normalized):
@@ -164,9 +167,12 @@ def download_media(url, cookie_path=None, audio_only=False, item_callback=None):
     )
 
     if platform == "youtube":
-        if source_type == "playlist":
+        if source_type in ("playlist", "channel"):
             log_info(logger, "YouTube playlist indirme basladi", stage="download.execute", url=url)
             result = download_youtube_playlist(url, save_path=platform_dir, cookie_path=resolved_cookie)
+            result["source_type"] = source_type
+            if source_type == "channel" and result.get("source_name") == "playlist":
+                result["source_name"] = "channel"
             result["downloader"] = "yt-dlp"
         else:
             log_info(logger, "YouTube video indirme basladi", stage="download.execute", url=url)
@@ -207,5 +213,3 @@ def download_media(url, cookie_path=None, audio_only=False, item_callback=None):
         item_count=len(result.get("items", [])),
     )
     return _persist_downloads(result)
-
-

--- a/utils/download_service.py
+++ b/utils/download_service.py
@@ -13,8 +13,10 @@ from utils.video_downloader import (
     extract_instagram_username,
     is_instagram_url,
     resolve_cookie_file,
+    sanitize_filename,
 )
 from utils.youtube_utils import (
+    extract_youtube_channel_name,
     extract_youtube_video_id,
     is_youtube_channel_url,
     is_youtube_playlist_url,
@@ -56,6 +58,22 @@ def _platform_download_dir(platform):
     os.makedirs(path, exist_ok=True)
     log_info(logger, "Platform indirme klasoru hazir", stage="download.prepare", platform=platform, path=path)
     return path
+
+
+def _source_download_dir(platform_dir, source_type, url):
+    if source_type == "channel":
+        channel_name = extract_youtube_channel_name(url)
+        if channel_name:
+            path = os.path.join(platform_dir, sanitize_filename(channel_name))
+            os.makedirs(path, exist_ok=True)
+            return path
+    if source_type == "profile_reels":
+        username = extract_instagram_username(url)
+        if username:
+            path = os.path.join(platform_dir, sanitize_filename(username))
+            os.makedirs(path, exist_ok=True)
+            return path
+    return platform_dir
 
 
 def _single_result(platform, source_type, url, item, download_dir, downloader):
@@ -156,6 +174,7 @@ def download_media(url, cookie_path=None, audio_only=False, item_callback=None):
     log_info(logger, "URL siniflandirildi", stage="download.classify", url=url, platform=platform, source_type=source_type)
     resolved_cookie = resolve_cookie_file(platform, cookie_path=cookie_path, cookie_dir=COOKIE_ROOT)
     platform_dir = _platform_download_dir(platform)
+    target_download_dir = _source_download_dir(platform_dir, source_type, url)
     log_info(
         logger,
         "Downloader secimi yapildi",
@@ -163,27 +182,29 @@ def download_media(url, cookie_path=None, audio_only=False, item_callback=None):
         platform=platform,
         source_type=source_type,
         cookie_file=resolved_cookie or "yok",
-        download_dir=platform_dir,
+        download_dir=target_download_dir,
     )
 
     if platform == "youtube":
         if source_type in ("playlist", "channel"):
             log_info(logger, "YouTube playlist indirme basladi", stage="download.execute", url=url)
-            result = download_youtube_playlist(url, save_path=platform_dir, cookie_path=resolved_cookie)
+            result = download_youtube_playlist(url, save_path=target_download_dir, cookie_path=resolved_cookie)
             result["source_type"] = source_type
-            if source_type == "channel" and result.get("source_name") == "playlist":
-                result["source_name"] = "channel"
+            if source_type == "channel":
+                channel_name = extract_youtube_channel_name(url)
+                if channel_name:
+                    result["source_name"] = channel_name
             result["downloader"] = "yt-dlp"
         else:
             log_info(logger, "YouTube video indirme basladi", stage="download.execute", url=url)
-            item = download_youtube_video(url, save_path=platform_dir, cookie_path=resolved_cookie)
-            result = _single_result(platform, source_type, url, item, platform_dir, "yt-dlp")
+            item = download_youtube_video(url, save_path=target_download_dir, cookie_path=resolved_cookie)
+            result = _single_result(platform, source_type, url, item, target_download_dir, "yt-dlp")
     else:
         if source_type == "profile_reels":
             log_info(logger, "Instagram profil reels indirme basladi", stage="download.execute", url=url)
             result = download_instagram_profile_reels(
                 url,
-                save_path=platform_dir,
+                save_path=target_download_dir,
                 cookie_path=resolved_cookie,
                 audio_only=audio_only,
                 item_callback=item_callback,
@@ -191,8 +212,8 @@ def download_media(url, cookie_path=None, audio_only=False, item_callback=None):
             result["downloader"] = "instaloader"
         else:
             log_info(logger, "Instagram reel indirme basladi", stage="download.execute", url=url)
-            item = download_instagram_video(url, save_path=platform_dir, cookie_path=resolved_cookie)
-            result = _single_result(platform, source_type, url, item, platform_dir, "instaloader")
+            item = download_instagram_video(url, save_path=target_download_dir, cookie_path=resolved_cookie)
+            result = _single_result(platform, source_type, url, item, target_download_dir, "instaloader")
 
     result["cookie_file"] = resolved_cookie
     if audio_only and not (platform == "instagram" and source_type == "profile_reels"):

--- a/utils/video_downloader.py
+++ b/utils/video_downloader.py
@@ -473,7 +473,12 @@ def download_instagram_profile_reels(url, save_path="downloads", cookie_path=Non
     if not username:
         raise ValueError("Instagram hesap URL'si bekleniyor.")
 
-    account_dir = os.path.abspath(os.path.join(save_path, sanitize_filename(username)))
+    base_save_path = os.path.abspath(save_path)
+    safe_username = sanitize_filename(username)
+    if os.path.basename(base_save_path) == safe_username:
+        account_dir = base_save_path
+    else:
+        account_dir = os.path.abspath(os.path.join(base_save_path, safe_username))
     log_info(logger, "Instagram profil reels akisi basladi", stage="instagram.profile", url=url, username=username, account_dir=account_dir)
     loader = _build_instaloader(account_dir, cookie_path=cookie_path)
     try:

--- a/utils/youtube_utils.py
+++ b/utils/youtube_utils.py
@@ -57,3 +57,22 @@ def extract_youtube_playlist_id(url):
 
 def is_youtube_playlist_url(url):
     return extract_youtube_playlist_id(url) is not None
+
+
+def is_youtube_channel_url(url):
+    parsed = _parse_url(url)
+    if not parsed:
+        return False
+
+    if not is_youtube_url(url):
+        return False
+
+    path = parsed.path.strip("/")
+    if not path:
+        return False
+
+    parts = path.split("/")
+    if parts[0] in ("channel", "c", "user", "@"):
+        return len(parts) >= 2 or parts[0] == "@"
+
+    return parts[0].startswith("@")

--- a/utils/youtube_utils.py
+++ b/utils/youtube_utils.py
@@ -72,7 +72,27 @@ def is_youtube_channel_url(url):
         return False
 
     parts = path.split("/")
-    if parts[0] in ("channel", "c", "user", "@"):
-        return len(parts) >= 2 or parts[0] == "@"
+    if parts[0] in ("channel", "c", "user"):
+        return len(parts) >= 2
 
     return parts[0].startswith("@")
+
+
+def extract_youtube_channel_name(url):
+    if not is_youtube_channel_url(url):
+        return None
+
+    parsed = _parse_url(url)
+    path = parsed.path.strip("/")
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return None
+
+    head = parts[0]
+    if head.startswith("@"):
+        return head.lstrip("@") or None
+
+    if head in ("channel", "c", "user") and len(parts) >= 2:
+        return parts[1]
+
+    return None


### PR DESCRIPTION
### Motivation
- Enable bulk downloading of all videos from YouTube channel pages (e.g. `@name/videos`, `/channel/...`, `/c/...`, `/user/...`) using the existing playlist/batch flow.
- Make the web UI explicit about channel-level bulk downloads so users know channel URLs are supported.

### Description
- Added `is_youtube_channel_url` to `utils/youtube_utils.py` to detect channel-style YouTube URLs.
- Updated `classify_download_url` in `utils/download_service.py` to return `source_type: "channel"` for channel URLs and extended the validation message accordingly.
- Reused the existing playlist batch flow in `download_media` for `channel` source type and preserved `source_type`/`source_name` on the result.
- Updated `templates/index.html` to mention channel bulk downloads, add a `YouTube channel` badge, and change the input placeholder to a channel URL example.

### Testing
- Ran `python -m compileall start_web.py utils templates/form_ui.py` which completed successfully with no compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48d256ab883248451ae6884ac3287)